### PR TITLE
Add DOTALL; fix #any which was producing the invalid r'[^]'.

### DIFF
--- a/re2/asm.py
+++ b/re2/asm.py
@@ -80,6 +80,8 @@ class Boundary(namedtuple('Boundary', ['character', 'reverse']), Asm):
 START_LINE = Boundary(r'^', None)
 END_LINE = Boundary(r'$', None)
 START_STRING = Boundary(r'\A', None)
+# TODO: \z matches purely at string end; \Z also matches before \n\z.
+# Should we expose \z or the pragmatic \Z you usually want?  Or both?
 END_STRING = Boundary(r'\Z', None)
 WORD_BOUNDARY = Boundary(r'\b', r'\B')
 

--- a/re2/asm.py
+++ b/re2/asm.py
@@ -42,6 +42,16 @@ class Concat(namedtuple('Concat', ['subs']), Asm):
 
 class CharacterClass(namedtuple('CharacterClass', ['characters', 'inverted']), Asm):
     def to_regex(self, wrap=False):
+        if len(self.characters) == 0:
+            if self.inverted:
+                return '.'  # Requires DOTALL flag.
+            else:
+                # Empty class (how did we get one?!) => need an expression that never matches.
+                # http://stackoverflow.com/a/942122/239657: a lookahead of empty string
+                # always matches, negative lookahead never does.
+                # The dot afterward is to express an exactly-one-char pattern,
+                # though it won't matter.
+                return '(?!).'
         if len(self.characters) == 1:
             c = self.characters[0]
             if isinstance(c, str):
@@ -57,7 +67,7 @@ class CharacterClass(namedtuple('CharacterClass', ['characters', 'inverted']), A
     def invert(self):
         return CharacterClass(self.characters, not self.inverted)
 
-ANY = CharacterClass([], True)
+ANY = CharacterClass([], inverted=True)
 LINEFEED = CharacterClass([r'\n'], False)
 CARRIAGE_RETURN = CharacterClass([r'\r'], False)
 TAB = CharacterClass([r'\t'], False)

--- a/re2/compiler.py
+++ b/re2/compiler.py
@@ -73,9 +73,9 @@ builtin_operators = {
 
 def compile(ast):
     macros = dict(builtin_macros)
-    # always compile as multiline
-    # this way we can have both #any and #nlf, both #ss and #sl
-    return asm.Setting('m', compile_ast(ast, macros))
+    # Always compile as MULTILINE (^$ match near \n) & DOTALL (. matches \n).
+    # This way we can have both #any (.) and #nlf (\N), both #ss (\A) and #sl (^).
+    return asm.Setting('ms', compile_ast(ast, macros))
 
 def compile_ast(ast, macros):
     return converters[type(ast)](ast, macros)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,8 +2,8 @@ import pytest
 from re2 import re, compile
 
 def test_re():
-    assert re('["a"]') == '(?m)a'
-    assert re('Number [capture 1+ #digit]') == r'(?m)Number\ (\d+)'
+    assert re('["a"]') == '(?ms)a'
+    assert re('Number [capture 1+ #digit]') == r'(?ms)Number\ (\d+)'
 
 def test_compile():
     assert compile('["a"]').search('bab')
@@ -11,8 +11,8 @@ def test_compile():
 
 def test_def():
     assert re('''[#recursive_dawg][
-    #yo=["Yo dawg, I heard you like "] #so_i_put=[", so I put some "] #in_your=[" in your "] #so_you_can=[" so you can "] #while_you=[" while you "] 
+    #yo=["Yo dawg, I heard you like "] #so_i_put=[", so I put some "] #in_your=[" in your "] #so_you_can=[" so you can "] #while_you=[" while you "]
     #dawg=[#yo "this" #so_i_put "of this" #in_your "regex" #so_you_can "recurse" #while_you "recurse"]
     #recursive_dawg=[#yo #dawg #so_i_put #dawg #in_your #dawg #so_you_can "recurse" #while_you "recurse"] ]'''
-    ) == ('(?m)Yo dawg, I heard you like Yo dawg, I heard you like this, so I put some of this in your regex so you can recurse while you recurse, so I put some Yo dawg, I heard you like this, so I put some of this in your regex so you can recurse while you recurse in your Yo dawg, I heard you like this, so I put some of this in your regex so you can recurse while you recurse so you can recurse while you recurse'
+    ) == ('(?ms)Yo dawg, I heard you like Yo dawg, I heard you like this, so I put some of this in your regex so you can recurse while you recurse, so I put some Yo dawg, I heard you like this, so I put some of this in your regex so you can recurse while you recurse in your Yo dawg, I heard you like this, so I put some of this in your regex so you can recurse while you recurse so you can recurse while you recurse'
         .replace(' ', '\\ ').replace(',', '\\,'))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,7 @@ from re2 import re, compile
 
 def test_re():
     assert re('["a"]') == '(?ms)a'
+    assert re('[0+ #any]') == '(?ms).*'
     assert re('Number [capture 1+ #digit]') == r'(?ms)Number\ (\d+)'
 
 def test_compile():

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -45,13 +45,15 @@ def test_builtin_macros():
     assert compile(Concat([Macro('#sl'), Literal('yo'), Macro('#el')])) == asm.Concat([asm.Boundary('^', None), asm.Literal('yo'), asm.Boundary('$', None)])
 
 def test_character_class():
-    assert compile(Either([Literal('a'), Literal('b')])) == asm.CharacterClass(['a', 'b'], False)
+    assert compile(Either([])) == asm.CharacterClass([], inverted=False)
+    assert compile(Either([Literal('a'), Literal('b')])) == asm.CharacterClass(['a', 'b'], inverted=False)
     assert compile(Operator('not', Either([Literal('a'), Literal('b')]))) == asm.CharacterClass(['a', 'b'], inverted=True)
     with pytest.raises(CompileError): compile(Operator('not', Either([Literal('a'), Literal('bc')])))
-    assert compile(Either([Literal('a'), Literal('b'), Literal('0')])) == asm.CharacterClass(['a', 'b', '0'], False)
-    assert compile(Either([Literal('a'), Macro('#d')])) == asm.CharacterClass(['a', r'\d'], False)
+    assert compile(Either([Literal('a'), Literal('b'), Literal('0')])) == asm.CharacterClass(['a', 'b', '0'], inverted=False)
+    assert compile(Either([Literal('a'), Macro('#d')])) == asm.CharacterClass(['a', r'\d'], inverted=False)
 
 def test_invert():
+    assert compile(Operator('not', Either([]))) == asm.CharacterClass([], inverted=True)
     assert compile(Operator('not', Literal('a'))) == asm.CharacterClass(['a'], inverted=True)
     assert compile(Operator('not', Either([Literal('a'), Literal('b')]))) == asm.CharacterClass(['a', 'b'], inverted=True)
     assert compile(Operator('not', Either([Literal('a'), Macro('#d')]))) == asm.CharacterClass(['a', r'\d'], inverted=True)

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -5,7 +5,7 @@ from re2.compiler import compile as _compile, CompileError
 
 def compile(ast):
     result = _compile(ast)
-    assert result.setting == 'm'
+    assert result.setting == 'ms'
     return result.sub
 
 def test_literal():


### PR DESCRIPTION
First commit just adds DOTALL modifier, which I suspect you wanted all along
(according to a comment about #any vs #nlf),
and is the Right Thing in any case <wink>.